### PR TITLE
Accept Either a CSS Selector or a HTML Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _Note: The Flybuy JS SDK will automatically determine that you want to use Googl
 
 ## Creating a map
 
-First, instantiate a new `Flybuy` object. After you have done that, you can call `flybuy.createMap` once you have the data you wish to load. The first argument to the method should the selector string. (not a DOM element)
+First, instantiate a new `Flybuy` object. After you have done that, you can call `flybuy.createMap` once you have the data you wish to load. The first argument to the method should the selector string or a DOM element.
 
 The instantiated `Flybuy` object does not need to be global in scope, you may assign it to whatever context works for your application.
 
@@ -30,6 +30,13 @@ window.addEventListener('DOMContentLoaded', () => {
     flybuy.createMap('div#map', data);
   });
 });
+```
+
+If you wish to pass a HTML element to `createMap`, you can do so:
+
+```
+let container = document.querySelector('div#map');
+flybuy.createMap(container, data);
 ```
 
 _Note: The DOM must be loaded before you attempt to create the map. The example uses the `DOMContentLoaded` event, but you could also move the `<script>` tag after the body._

--- a/flybuy.js
+++ b/flybuy.js
@@ -117,11 +117,19 @@ class Flybuy {
     this._centerMap();
   }
 
-  _findContainerElement(selector) {
-    let element = document.querySelector(selector);
+  _findContainerElement(containerSelector) {
+    let element = containerSelector;
 
-    if (!element) {
-      throw new Error(`Unable to find DOM element for selector: "${selector}"`);
+    // If it's a string, assume it's a selector and not an element
+    if (typeof(containerSelector) === 'string') {
+      element = document.querySelector(containerSelector);
+    }
+
+    // Make sure the element exists in the visible DOM
+    let elementExists = document.body.contains(element);
+
+    if (!elementExists) {
+      throw new Error(`Unable to find DOM element for selector: "${containerSelector}"`);
     }
     else {
       return element;


### PR DESCRIPTION
When creating a map, you can now pass either a CSS selector or a HTMLElement to `createMap`:
```
flybuy.createMap('div#map', data);

let element = document.querySelector('div#map');
flybuy.createMap(element, data);
```

Fixes #3.