### PR TITLE
Map Customization Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,43 @@ flybuy.createMap(container, data);
 
 _Note: The DOM must be loaded before you attempt to create the map. The example uses the `DOMContentLoaded` event, but you could also move the `<script>` tag after the body._
 
-## Showing the navigation controls on the map
+## Customizing the map (Google)
 
-By default, the navigation controls (zoom, orient, street view, etc.) are hidden. If you wish to display them, you can pass `true` to `createMap`:
+The `createMap` method takes an optional configuration object that can be used to customize the appearance of the map. The object is passed along directly to the Google Maps constructor so you can use any configuration options found in the Google SDK.
+
+The example below turns off navigation controls and POI markers:
 ```
-let showControls = true;
-flybuy.createMap(container, data, showControls);
+let configOptions = {
+  disableDefaultUI: true,
+  styles: [{
+    featureType: 'poi',
+    stylers: [{
+      visibility: 'off'
+    }]
+  }]
+};
+
+fetch(jsonFile).then(response => response.json()).then(data => {
+  flybuy.createMap('div#map', data, configOptions);
+});
 ```
+
+## Customizing the map (Mapbox)
+
+Because Mapbox has very different syntax for configuring their maps, we currenly only support one directive, `showNavigationControl`, that turns on/off navigation controls:
+
+```
+let configOptions = {showNavigationControl: false};
+flybuy.createMap(container, data, configOptions);
+```
+
+_Note: If you need additional configuration options, get in touch with your customer success manager and we'll evaluate adding it._
 
 ## Completion handler hook when creating maps
 
 If you need a completion handler hook when creating a map, `createMap` returns a Promise:
 ```
-flybuy.createMap(container, data, showControls)
+flybuy.createMap(container, data)
   .then(success => {})
   .catch(success => {})
 });

--- a/flybuy.js
+++ b/flybuy.js
@@ -15,7 +15,7 @@ class Flybuy {
 
   // PUBLIC METHODS
 
-  createMap(containerSelector, payloadData, showControls=false) {
+  createMap(containerSelector, payloadData, configOptions={}) {
     return new Promise((resolve, reject) => {
 
       // Try to determine which map provider (Google, Mapbox, etc.) is being used
@@ -38,7 +38,7 @@ class Flybuy {
       }
 
       // Attempt to draw the map for the provider
-      this.map = this._initMapForProvider(this.provider, containerElement, payloadData.data, showControls)
+      this.map = this._initMapForProvider(this.provider, containerElement, payloadData.data, configOptions)
         .then(map => {
           this.map = map;
           this._drawPremises(payloadData.data);
@@ -146,7 +146,7 @@ class Flybuy {
     }
   }
 
-  _initMapForProvider(provider, containerElement, data, showControls) {
+  _initMapForProvider(provider, containerElement, data, configOptions) {
     return new Promise((resolve, reject) => {
       let lat = 0.0;
       let lng = 0.0;
@@ -159,7 +159,7 @@ class Flybuy {
 
       if (provider === 'google') {
         let centerPoint = new google.maps.LatLng(lat,lng);
-        let map = new google.maps.Map(containerElement, {disableDefaultUI: !showControls});
+        let map = new google.maps.Map(containerElement, configOptions);
 
         let bounds = new google.maps.LatLngBounds();
         bounds.extend(centerPoint);
@@ -178,7 +178,7 @@ class Flybuy {
         let bounds = new mapboxgl.LngLatBounds([lng,lat], [lng,lat]);
         map.fitBounds(bounds);
 
-        if (showControls === true) {
+        if (configOptions.showNavigationControl === true) {
           map.addControl(new mapboxgl.NavigationControl());
         }
 

--- a/google.html
+++ b/google.html
@@ -12,8 +12,13 @@
       window.addEventListener('DOMContentLoaded', () => {
         let jsonFile = 'sample_data/initial_orders_api.json';
 
+        let configOptions = {
+          disableDefaultUI: true,
+          styles: [{ featureType: "poi", stylers: [{ visibility: "off" }] }]
+        };
+
         fetch(jsonFile).then(response => response.json()).then(data => {
-          flybuy.createMap('div#map', data);
+          flybuy.createMap('div#map', data, configOptions);
         });
       });
     </script>

--- a/mapbox.html
+++ b/mapbox.html
@@ -12,9 +12,10 @@
 
       window.addEventListener('DOMContentLoaded', () => {
         let jsonFile = 'sample_data/initial_orders_api.json';
+        let configOptions = {showNavigationControl: false};
 
         fetch(jsonFile).then(response => response.json()).then(data => {
-          flybuy.createMap('div#map', data);
+          flybuy.createMap('div#map', data, configOptions);
         });
       });
     </script>


### PR DESCRIPTION
We now support customizing maps via a configuration object.

*Note: `showControls` has been removed in favor of this more flexible configuration approach.*

If you are using Google Maps, you can pass any of the options that the Google Maps SDK supports and it will be passed directly to their map constructor.

If you are using Mapbox GL Maps, we currenly only support a `showNavigationControls` directive. (We can add more configuration keys as needed)